### PR TITLE
feat(create-lit-xml): add strictTemplateValues option

### DIFF
--- a/packages/lit-xml/src/create-lit-xml.ts
+++ b/packages/lit-xml/src/create-lit-xml.ts
@@ -5,11 +5,19 @@ const DEFAULT_OPTIONS: Readonly<LitXmlOptions> = {
   format: false,
   indent: 2,
   validators: [],
+  strictTemplateValues: false,
 };
 
-export type XmlTemplateLiteral = (xmlLiterals: TemplateStringsArray, ...values: unknown[]) => XmlFragment;
+export type XmlPrimitive = string | number | boolean | bigint | XmlFragment | XmlFragment[];
 
-export function createLitXml(overrideOptions?: Partial<LitXmlOptions>) {
+export type XmlTemplateLiteralTag<T> = (xmlLiterals: TemplateStringsArray, ...values: T[]) => XmlFragment;
+
+export type XmlTemplateLiteral = XmlTemplateLiteralTag<unknown>;
+export type StrictXmlTemplateLiteral = XmlTemplateLiteralTag<XmlPrimitive>;
+
+export function createLitXml<T extends Partial<LitXmlOptions>>(
+  overrideOptions?: T
+): XmlTemplateLiteralTag<T extends { strictTemplateValues: true } ? XmlPrimitive : unknown> {
   const options = Object.freeze({ ...DEFAULT_OPTIONS, ...overrideOptions });
   return function xml(xmlLiterals: TemplateStringsArray, ...values: unknown[]): XmlFragment {
     return new XmlFragment(xmlLiterals, values, options);

--- a/packages/lit-xml/src/lit-xml-options.ts
+++ b/packages/lit-xml/src/lit-xml-options.ts
@@ -4,4 +4,9 @@ export interface LitXmlOptions {
   readonly validators: Validator[];
   readonly format: boolean;
   readonly indent: number;
+  /**
+   * Enable strict mode for the template values.
+   * This mode requires all template values to be a xml primitive (`string | number | boolean | bigint | XmlFragment | XmlFragment[]`)
+   */
+  readonly strictTemplateValues: boolean;
 }


### PR DESCRIPTION
Add a `strictTemplateValues` option to the `createLitXml` options. This mode requires templated values to be a primitive of `string | number | boolean | bigint | XmlFragment | XmlFragment[]`. Values of `any`, `undefined`, `null` or another object give a compile error. Only impacts compile-time checks, no runtime checks are done for the types
