### PR TITLE
fix(vscode-lit-xml): remove activation point from extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,9 +1,0 @@
-{
-  // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
-  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-
-  // List of extensions which should be recommended for users of this workspace.
-  "recommendations": ["streetsidesoftware.code-spell-checker", "esbenp.prettier-vscode", "dbaeumer.vscode-eslint"],
-  // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
-  "unwantedRecommendations": []
-}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,13 +22,6 @@
       "internalConsoleOptions": "openOnSessionStart",
       "skipFiles": ["<node_internals>/**"],
       "outFiles": ["${workspaceFolder}/packages/*/dist/**/*.js"]
-    },
-    {
-      "name": "Launch Extension",
-      "type": "extensionHost",
-      "request": "launch",
-      "runtimeExecutable": "${execPath}",
-      "args": ["--extensionDevelopmentPath=${workspaceFolder}/packages/vscode-lit-xml"]
     }
   ]
 }

--- a/packages/vscode-lit-xml/.vscode/launch.json
+++ b/packages/vscode-lit-xml/.vscode/launch.json
@@ -8,7 +8,6 @@
       "name": "Launch Extension",
       "type": "extensionHost",
       "request": "launch",
-      "runtimeExecutable": "${execPath}",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}"]
     }
   ]

--- a/packages/vscode-lit-xml/package.json
+++ b/packages/vscode-lit-xml/package.json
@@ -5,11 +5,11 @@
   "publisher": "hugo-vrijswijk",
   "license": "Apache-2.0",
   "version": "0.4.0",
-  "main": "dist/src/index",
   "icon": "images/icon.png",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nicojs/lit-xml.git"
+    "url": "https://github.com/nicojs/lit-xml.git",
+    "directory": "packages/vscode-lit-xml"
   },
   "scripts": {
     "publish": "vsce publish -p $VSCODE_TOKEN",
@@ -27,12 +27,6 @@
     "typescript",
     "xml",
     "template"
-  ],
-  "activationEvents": [
-    "onLanguage:javascript",
-    "onLanguage:javascriptreact",
-    "onLanguage:typescript",
-    "onLanguage:typescriptreact"
   ],
   "contributes": {
     "grammars": [

--- a/packages/vscode-lit-xml/src/index.ts
+++ b/packages/vscode-lit-xml/src/index.ts
@@ -1,3 +1,0 @@
-export function activate() {
-  // Entrypoint of the extension. Since this extension has no functionality beyond highlighting it is empty
-}

--- a/packages/vscode-lit-xml/src/tsconfig.json
+++ b/packages/vscode-lit-xml/src/tsconfig.json
@@ -1,6 +1,0 @@
-{
-  "extends": "../../../tsconfig.settings.json",
-  "compilerOptions": {
-    "outDir": "../dist/src"
-  }
-}

--- a/packages/vscode-lit-xml/tsconfig.json
+++ b/packages/vscode-lit-xml/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "files": [],
-  "references": [
-    {
-      "path": "src"
-    }
-  ]
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,6 @@
   "references": [
     {
       "path": "packages/lit-xml"
-    },
-    {
-      "path": "packages/vscode-lit-xml"
     }
   ]
 }

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.settings.json",
-  "include": ["packages/lit-xml", "packages/vscode-lit-xml"]
+  "include": ["packages/lit-xml"]
 }

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -13,5 +13,8 @@
   ],
   "settings": {
     "task.autoDetect": "off"
+  },
+  "extensions": {
+    "recommendations": ["streetsidesoftware.code-spell-checker", "esbenp.prettier-vscode", "dbaeumer.vscode-eslint", "hugo-vrijswijk.vscode-lit-xml"]
   }
 }


### PR DESCRIPTION
This fixes compatibility with [Virtual Workspaces](https://github.com/microsoft/vscode/wiki/Virtual-Workspaces) and makes the extension a little bit simpler.
