### PR TITLE
perf: improve XmlFragment toString rendering performance

### DIFF
--- a/packages/lit-xml/src/xml-fragment.ts
+++ b/packages/lit-xml/src/xml-fragment.ts
@@ -14,12 +14,10 @@ export class XmlFragment {
    * @internal
    */
   public toStringRaw() {
-    const xmlBuilder: string[] = [];
+    let stringBuilder = '';
     for (let i = 0; i < this.values.length; i++) {
-      xmlBuilder.push(this.xmlLiterals[i]);
-      xmlBuilder.push(valueToString(this.values[i]));
+      stringBuilder = stringBuilder.concat(this.xmlLiterals[i], valueToString(this.values[i]));
     }
-    xmlBuilder.push(this.xmlLiterals[this.xmlLiterals.length - 1]);
-    return xmlBuilder.join('');
+    return stringBuilder + this.xmlLiterals[this.xmlLiterals.length - 1];
   }
 }


### PR DESCRIPTION
Improves performance of `toStringRaw` by using string concatenation instead of array pushing. Pre-IE10 array pushing was faster, but I don't think that is a good target to have 😀. All modern JS engines use something called '[ropes](https://www.cs.tufts.edu/comp/150FP/archive/hans-boehm/ropes.pdf)' which make string concatenation much faster.

In some non-scientific performance testing, I found the new implementation to be about twice as fast when concatenating large arrays.

In case you want to test out the performance, run and time this script:

```typescript
import { xml } from './create-lit-xml';

const xmlFragment = xml`<catalog>${Array(100000).fill(xml`<book id="bk101">
      <author>Gambardella, Matthew</author>
      <title>XML Developer's Guide</title>
      <genre>Computer</genre>
      <price>44.95</price>
      <publish_date>2000-10-01</publish_date>
      <description>An in-depth look at creating applications 
      with XML.</description>
   </book>`)}</catalog>`;

const profile = () => {
  for (let index = 0; index < 1000; index++) {
    xmlFragment.toString();
  }
};

profile();

```